### PR TITLE
Specify minimum golang version

### DIFF
--- a/content/getting-started.md
+++ b/content/getting-started.md
@@ -8,7 +8,7 @@ title: Getting Started
 ## Installation
 
 * __From Source__\
-If you have Go installed and GOPATH environment variable properly set up, you
+If you have Go 1.9 or higher installed and GOPATH environment variable properly set up, you
 can download and install `cloudprober` using the following commands:
 ```
 go get github.com/google/cloudprober


### PR DESCRIPTION
go get command fails on 1.8 and earlier as Duration.Round has been added in 1.9 only (https://golang.org/doc/go1.9#minor_library_changes )